### PR TITLE
Fix model reference in predictive text

### DIFF
--- a/tex/predictive.tex
+++ b/tex/predictive.tex
@@ -64,7 +64,7 @@ Model 1 has an R-squared of 0.253 in the training set. From the scatter plot bel
 
 \subsubsection{Model 2}
 
-Model 1 has an R-squared of 0.876 in the training set. From the residual scatter below, we see that the residuals become more volatile over time. Indeed, the R-squared is -0.233 (yes, negative) for the test data. That means using the regression model is worse than just guessing the average from the post-1970 data.
+Model 2 has an R-squared of 0.876 in the training set. From the residual scatter below, we see that the residuals become more volatile over time. Indeed, the R-squared is -0.233 (yes, negative) for the test data. That means using the regression model is worse than just guessing the average from the post-1970 data.
 
 \begin{figure}[H]
 \centering


### PR DESCRIPTION
## Summary
- Correct R-squared reference in predictive model section to state "Model 2" instead of "Model 1"

## Testing
- `make -C tex predictive` *(fails: pdflatex: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c631198aec8327a51efe74a49307ba