### PR TITLE
Fix duplicate word in predictive validation example

### DIFF
--- a/tex/predictive.tex
+++ b/tex/predictive.tex
@@ -177,7 +177,7 @@ The most basic form of validation goes like this: randomly split the data into t
 \begin{enumerate}
 \item Train each model variant (eg different polynomial specifications) on the training set.
 \item Measure the error on the dev set.
-\item Pick model with the lowest error on the the dev set.
+\item Pick model with the lowest error on the dev set.
 \item Reserve the test set to get a final measure of the model performance.
 \end{enumerate}
 


### PR DESCRIPTION
## Summary
- remove duplicate word from predictive model selection step

## Testing
- `make predictive` *(fails: pdflatex: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6311dcb4083278120400bd0af7768