### PR TITLE
Clarify tcolorbox placement

### DIFF
--- a/tex/mystyle.sty
+++ b/tex/mystyle.sty
@@ -19,7 +19,7 @@
 
 
 \usepackage[breakable]{tcolorbox}
-\tcbset{nobeforeafter} % prevents tcolorboxes being placing in paragraphs
+\tcbset{nobeforeafter} % prevents tcolorboxes from being placed in paragraphs.
 
 %\newtheorem{definition}{Definition}
 


### PR DESCRIPTION
## Summary
- Clarified tcolorbox settings comment to state it prevents boxes from being placed inside paragraphs.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6312ba5fc83279a24b8b02b180516